### PR TITLE
fix: remove default image

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,13 +15,21 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
+<<<<<<< HEAD
 version: 0.3.1
+=======
+version: 0.1.1
+>>>>>>> 2a91f6b (Remove default image)
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+<<<<<<< HEAD
 appVersion: 0.2.19
+=======
+appVersion: "0.2.19"
+>>>>>>> 2a91f6b (Remove default image)
 dependencies:
   - name: pgo
     version: "5.4.1"

--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,21 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-<<<<<<< HEAD
 version: 0.3.1
-=======
-version: 0.1.1
->>>>>>> 2a91f6b (Remove default image)
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-<<<<<<< HEAD
 appVersion: 0.2.19
-=======
-appVersion: "0.2.19"
->>>>>>> 2a91f6b (Remove default image)
 dependencies:
   - name: pgo
     version: "5.4.1"

--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.2
+appVersion: 0.2.19
 dependencies:
   - name: pgo
     version: "5.4.1"

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -3,7 +3,6 @@
 # Declare variables to be passed into your templates.
 
 postgresVersion: 15
-imagePostgres: paradedb/paradedb
 installOperator: true
 patroni:
     dynamicConfiguration:


### PR DESCRIPTION
**Ticket(s) Closed**

N/A

**What**
Remove the default image from the values file.

**Why**
Because if you specify the image in the postgres operator instead of each individual cluster, its much easier to manage updates and rollbacks.

**How**
Remove default postgres image from chart values.

**Tests**
Manually tested.