### PR TITLE
feat: switch operator for Zalando

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -23,7 +23,11 @@ version: 0.3.3
 # It is recommended to use it with quotes.
 appVersion: 0.2.19
 dependencies:
-  - name: pgo
-    version: "5.4.1"
-    repository: oci://registry.developers.crunchydata.com/crunchydata
+  - name: postgres-operator
+    version: "1.10.1"
+    repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
     condition: installOperator
+  - name: postgres-operator-ui
+    version: "1.10.1"
+    repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui
+    condition: installUI

--- a/charts/paradedb/templates/postgres.yaml
+++ b/charts/paradedb/templates/postgres.yaml
@@ -1,214 +1,65 @@
-apiVersion: postgres-operator.crunchydata.com/v1beta1
-kind: PostgresCluster
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
 metadata:
-  name: {{ default .Release.Name .Values.name }}
+  name: {{ .Release.Name }}-cluster
+  {{- with .Values.metadata.labels }}
+  labels:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.metadata.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
-  postgresVersion: {{ required "You must set the version of Postgres to deploy." .Values.postgresVersion }}
-  {{- if .Values.postGISVersion }}
-  postGISVersion: {{ quote .Values.postGISVersion }}
+  dockerImage: {{ .Values.spec.dockerImage }}
+  teamId: {{ .Values.spec.teamId }}
+  numberOfInstances: {{ .Values.spec.numberOfInstances }}
+  users: {{ toYaml .Values.spec.users | nindent 4 }}
+  {{- with .Values.spec.usersWithSecretRotation }}
+  usersWithSecretRotation: {{ toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.imagePostgres }}
-  image: {{ .Values.imagePostgres | quote }}
+  {{- with .Values.spec.usersWithInPlaceSecretRotation }}
+  usersWithInPlaceSecretRotation: {{ toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.port }}
-  port: {{ .Values.port }}
+  enableMasterLoadBalancer: {{ .Values.spec.enableMasterLoadBalancer }}
+  enableReplicaLoadBalancer: {{ .Values.spec.enableReplicaLoadBalancer }}
+  enableConnectionPooler: {{ .Values.spec.enableConnectionPooler }}
+  enableReplicaConnectionPooler: {{ .Values.spec.enableReplicaConnectionPooler }}
+  enableMasterPoolerLoadBalancer: {{ .Values.spec.enableMasterPoolerLoadBalancer }}
+  enableReplicaPoolerLoadBalancer: {{ .Values.spec.enableReplicaPoolerLoadBalancer }}
+  allowedSourceRanges: {{ toYaml .Values.spec.allowedSourceRanges | nindent 4 }}
+  databases: {{ toYaml .Values.spec.databases | nindent 4 }}
+  preparedDatabases: {{ toYaml .Values.spec.preparedDatabases | nindent 4 }}
+  postgresql:
+    version: "{{ .Values.spec.postgresql.version }}"
+    parameters: {{ toYaml .Values.spec.postgresql.parameters | nindent 6 }}
+  {{- with .Values.spec.env }}
+  env:
+{{ toYaml . | indent 4 }}
   {{- end }}
-  {{- if .Values.instances }}
-  instances:
-{{ toYaml .Values.instances | indent 4 }}
-  {{- else }}
-  instances:
-    - name: {{ default "instance1" .Values.instanceName | quote }}
-      replicas: {{ default 1 .Values.instanceReplicas }}
-      dataVolumeClaimSpec:
-        {{- if .Values.instanceStorageClassName }}
-        storageClassName: {{ .Values.instanceStorageClassName | quote }}
-        {{- end }}
-        accessModes:
-        - "ReadWriteOnce"
-        resources:
-          requests:
-            storage: {{ default "1Gi" .Values.instanceSize | quote }}
-      {{- if or .Values.instanceMemory .Values.instanceCPU }}
-      resources:
-        limits:
-          cpu: {{ default "" .Values.instanceCPU | quote }}
-          memory: {{ default "" .Values.instanceMemory | quote }}
-      {{- end }}
+  volume:
+    size: {{ .Values.spec.volume.size }}
+  {{- with .Values.spec.additionalVolumes }}
+  additionalVolumes:
+{{ toYaml . | indent 4 }}
   {{- end }}
-  backups:
-    pgbackrest:
-      {{- if .Values.imagePgBackRest }}
-      image: {{ .Values.imagePgBackRest | quote }}
-      {{- end }}
-      {{- if .Values.pgBackRestConfig }}
-{{ toYaml .Values.pgBackRestConfig | indent 6 }}
-      {{- else if .Values.multiBackupRepos }}
-      configuration:
-      - secret:
-          name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
-      global:
-        {{- range $index, $repo := .Values.multiBackupRepos }}
-        {{- if or $repo.s3 $repo.gcs $repo.azure }}
-        repo{{ add $index 1 }}-path: /pgbackrest/{{ $.Release.Namespace }}/{{ default $.Release.Name $.Values.name }}/repo{{ add $index 1 }}
-        {{- end }}
-        {{- end }}
-      repos:
-      {{- range $index, $repo := .Values.multiBackupRepos }}
-      - name: repo{{ add $index 1 }}
-        {{- if $repo.volume }}
-        volume:
-          volumeClaimSpec:
-            {{- if $repo.volume.backupsStorageClassName }}
-            storageClassName: {{ .Values.backupsStorageClassName | quote }}
-            {{- end }}
-            accessModes:
-            - "ReadWriteOnce"
-            resources:
-              requests:
-                storage: {{ default "1Gi" $repo.volume.backupsSize | quote }}
-        {{- else if $repo.s3 }}
-        s3:
-          bucket: {{ $repo.s3.bucket | quote }}
-          endpoint: {{ $repo.s3.endpoint | quote }}
-          region: {{ $repo.s3.region | quote }}
-        {{- else if $repo.gcs }}
-        gcs:
-          bucket: {{ $repo.gcs.bucket | quote }}
-        {{- else if $repo.azure }}
-        azure:
-          container: {{ $repo.azure.container | quote }}
-        {{- end }}
-      {{- end }}
-      {{- else if .Values.s3 }}
-      configuration:
-      - secret:
-          name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
-      global:
-        repo1-path: /pgbackrest/{{ .Release.Namespace }}/{{ default .Release.Name .Values.name }}/repo1
-        {{- if .Values.s3.encryptionPassphrase }}
-        repo1-cipher-type: aes-256-cbc
-        {{- end }}
-      repos:
-      - name: repo1
-        s3:
-          bucket: {{ .Values.s3.bucket | quote }}
-          endpoint: {{ .Values.s3.endpoint | quote }}
-          region: {{ .Values.s3.region | quote }}
-      {{- else if .Values.gcs }}
-      configuration:
-      - secret:
-          name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
-      global:
-        repo1-path: /pgbackrest/{{ .Release.Namespace }}/{{ default .Release.Name .Values.name }}/repo1
-      repos:
-      - name: repo1
-        gcs:
-          bucket: {{ .Values.gcs.bucket | quote }}
-      {{- else if .Values.azure }}
-      configuration:
-      - secret:
-          name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
-      global:
-        repo1-path: /pgbackrest/{{ .Release.Namespace }}/{{ default .Release.Name .Values.name }}/repo1
-      repos:
-      - name: repo1
-        azure:
-          container: {{ .Values.azure.container | quote }}
-      {{- else }}
-      repos:
-      - name: repo1
-        volume:
-          volumeClaimSpec:
-            {{- if .Values.backupsStorageClassName }}
-            storageClassName: {{ .Values.backupsStorageClassName | quote }}
-            {{- end }}
-            accessModes:
-            - "ReadWriteOnce"
-            resources:
-              requests:
-                storage: {{ default "1Gi" .Values.backupsSize | quote }}
-      {{- end }}
-  {{- if or .Values.pgBouncerReplicas .Values.pgBouncerConfig }}
-  proxy:
-    pgBouncer:
-      {{- if .Values.imagePgBouncer }}
-      image: {{ .Values.imagePgBouncer | quote }}
-      {{- end }}
-      {{- if .Values.pgBouncerConfig }}
-{{ toYaml .Values.pgBouncerConfig | indent 6 }}
-      {{- else }}
-      replicas: {{ .Values.pgBouncerReplicas }}
-      {{- end }}
+  enableShmVolume: {{ .Values.spec.enableShmVolume }}
+  resources: {{ toYaml .Values.spec.resources | nindent 4 }}
+  patroni: {{ toYaml .Values.spec.patroni | nindent 4 }}
+  {{- with .Values.spec.initContainers }}
+  initContainers:
+{{ toYaml . | indent 4 }}
   {{- end }}
-  {{- if .Values.patroni }}
-  patroni:
-{{ toYaml .Values.patroni | indent 4 }}
+  {{- with .Values.spec.sidecars }}
+  sidecars:
+{{ toYaml . | indent 4 }}
   {{- end }}
-  {{- if .Values.users }}
-  users:
-{{ toYaml .Values.users | indent 4 }}
+  tls: {{ toYaml .Values.spec.tls | nindent 4 }}
+  {{- with .Values.spec.nodeAffinity }}
+  nodeAffinity:
+{{ toYaml . | indent 4 }}
   {{- end }}
-  {{- if .Values.service }}
-  service:
-{{ toYaml .Values.service | indent 4 }}
-  {{- end }}
-  {{- if .Values.dataSource }}
-  dataSource:
-{{ toYaml .Values.dataSource | indent 4 }}
-  {{- end }}
-  {{- if .Values.databaseInitSQL }}
-  databaseInitSQL:
-    name: {{ required "A ConfigMap name is required for running bootstrap SQL." .Values.databaseInitSQL.name | quote }}
-    key: {{ required "A key in a ConfigMap containing any bootstrap SQL is required." .Values.databaseInitSQL.key | quote }}
-  {{- end }}
-  {{- if .Values.imagePullPolicy }}
-  imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-  {{- end }}
-  {{- if .Values.imagePullSecrets }}
-  imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 4 }}
-  {{- end }}
-  {{- if .Values.disableDefaultPodScheduling }}
-  disableDefaultPodScheduling: true
-  {{- end }}
-  {{- if .Values.metadata }}
-  metadata:
-{{ toYaml .Values.metadata | indent 4 }}
-  {{- end }}
-  {{- if .Values.monitoring }}
-  monitoring:
-    pgmonitor:
-      exporter:
-        image: {{ default "" .Values.imageExporter | quote }}
-        {{- if .Values.monitoringConfig }}
-{{ toYaml .Values.monitoringConfig | indent 8 }}
-        {{- end }}
-  {{- end }}
-  {{- if .Values.shutdown }}
-  shutdown: true
-  {{- end }}
-  {{- if .Values.standby }}
-  standby:
-    enabled: {{ .Values.standby.enabled }}
-    repoName: {{ .Values.standby.repoName }}
-    host: {{ .Values.standby.host }}
-    port: {{ .Values.standby.port }}
-  {{- end }}
-  {{- if .Values.supplementalGroups }}
-  supplementalGroups:
-{{ toYaml .Values.supplementalGroups | indent 4 }}
-  {{- end }}
-  {{- if .Values.openshift }}
-  openshift: true
-  {{- else if eq .Values.openshift false }}
-  openshift: false
-  {{- end }}
-  {{- if .Values.customTLSSecret }}
-  customTLSSecret:
-{{ toYaml .Values.customTLSSecret | indent 4 }}
-  {{- end }}
-  {{- if .Values.customReplicationTLSSecret }}
-  customReplicationTLSSecret:
-{{ toYaml .Values.customReplicationTLSSecret | indent 4 }}
+  {{- with .Values.spec.streams }}
+  streams:
+{{ toYaml . | indent 4 }}
   {{- end }}

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -1,386 +1,246 @@
-# For a full explanation of how to set up the custom resource, please refer to
-# the documentation:
-#    https://access.crunchydata.com/documentation/postgres-operator/v5/
-
-############
-# Operator #
-############
-
-# controllerImages are used to run the operator's controllers.
-# The cluster image defined below runs the PostgresCluster and PGUpgrade controllers.
-# controllerImages:
-#   cluster: registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.4.2-0
-
-# relatedImages are used when an image is omitted from PostgresCluster or PGUpgrade specs.
-pgo:
-  relatedImages:
-    postgres_15:
-      image: paradedb/paradedb
-#   postgres_15_gis_3.3:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-15.4-3.3-0
-#   postgres_14:
-#     image: paradedb/paradedb
-#   postgres_14_gis_3.1:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.9-3.1-0
-#   postgres_14_gis_3.2:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.9-3.2-0
-#   postgres_14_gis_3.3:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.9-3.3-0
-#   pgadmin:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-17
-#   pgbackrest:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.47-0
-#   pgbouncer:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.19-4
-#   pgexporter:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.4.2-0
-#   pgupgrade:
-#     image: registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.4.2-0
-
-# singleNamespace controls where PGO watches for PostgresClusters. When false,
-# PGO watches for and responds to PostgresClusters in all namespaces. When true,
-# PGO watches only the namespace in which it is installed.
-# singleNamespace: false
-
-# debug allows you to enable or disable the "debug" level of logging.
-# debug: true
-
-# imagePullSecretNames is a list of secret names to use for pulling controller images.
-# More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-# imagePullSecretNames: []
-
-# Resource configuration of the PostgresCluster and PGUpgrade controllers.
-# resources:
-#   controller: {}
-
-# Define custom labels for PGO pods
-# Note: Defining labels that overlap with any Crunchy Data label, for example,
-# postgres-operator.crunchydata.com, will cause an error
-# customPodLabels:
-#  example.com: custom-label
-
-###########
-# General #
-###########
-
-# name is the name of the cluster. This defaults to the name of the Helm
-# release.
-# name: hippo
-
-# postgresVersion sets the version to deploy. This version number needs to be
-# available as one of the "RELATED_IMAGE_POSTGRES_..." images as part of the PGO
-# installation if you want to deploy the image without setting the "postgres"
-# image variable. This value is required.
-postgresVersion: 15
-
-# Whether to install the Crunchy Operator alongside ParadeDB
 installOperator: true
+installUI: true
 
-# postGISVersion if set and coupled with a PostGIS enabled container, enables
-# PostGIS. This version number needs to be available as one of the
-# "RELATED_IMAGE_POSTGRES_..." images as part of the PGO installation if you
-# want to deploy the image without setting the "postgres" image variable.
-# postGISVersion: 3.1
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: paradedb-cluster  # Name of the PostgreSQL cluster resource
+  # labels: # Labels for the PostgreSQL cluster resource
+  #   application: test-app
+  #   environment: demo
+  # annotations:  # Annotations for the PostgreSQL cluster resource
+  #   "acid.zalan.do/controller": "second-operator"  # Specify a different operator to control this cluster
+  #   "delete-date": "2020-08-31"  # Cluster can only be deleted on this date if configured
+  #   "delete-clustername": "acid-test-cluster"  # Cluster can only be deleted when the name matches if configured
 
-# NOTE: pgBackRest is enabled by default. It must be set in
-# "RELATED_IMAGE_PGBACKREST" on the PGO deployment, otherwise you will need to
-# override the "pgBackRest" image.
+spec:
+  dockerImage: ghcr.io/zalando/spilo-15:3.0-p1  # Docker image to use for the PostgreSQL cluster
+  # teamId: "paradedb"  # Team responsible for the cluster
+  numberOfInstances: 2  # Number of PostgreSQL instances (includes master and replicas)
 
-# pgBouncerReplicas sets the number of pgBouncer instances to deploy. The
-# default is 0. You need to set this to at least 1 to deploy pgBouncer or set
-# "pgBouncerConfig". Setting "pgBouncerConfig" will override the value of
-# pgBouncerReplicas. The "RELATED_IMAGE_PGBOUNCER" in the PGO deployment must be
-# set if you want to enable this without explicitly setting "pgBouncer".
-# pgBouncerReplicas: 1
+  users:  # Application/Robot users
+    paradedb:
+    - superuser  # PostgreSQL superuser role
+    - createdb  # Role that allows creation of databases
+#   foo_user: []  # Empty list means no specific roles
+#    flyway: []
+#  usersWithSecretRotation:
+#  - foo_user
+#  usersWithInPlaceSecretRotation:
+#  - flyway
+#  - bar_owner_user
 
-# monitoring enables the ability to monitor the Postgres cluster through a
-# metrics exporter that can be scraped by Prometheus. This defaults to the value
-# below.
-# monitoring: false
+  enableMasterLoadBalancer: false  # If true, a load balancer for the master is created
+  enableReplicaLoadBalancer: false  # If true, a load balancer for the replicas is created
+  enableConnectionPooler: false  # Enable/disable connection pooler deployment
+  enableReplicaConnectionPooler: false  # Enable connection pooler for replica service
+  enableMasterPoolerLoadBalancer: false  # Enable load balancer for master connection pooler
+  enableReplicaPoolerLoadBalancer: false  # Enable load balancer for replica connection pooler
 
-###################
-# Image Overrides #
-###################
+  allowedSourceRanges:  # Allowed IP ranges for master and replica services
+  - 127.0.0.1/32
 
-# imagePostgres can be a Postgres or GIS-enabled Postgres image. This defaults to the
-# below value. "postgresVersion" needs to match the version of Postgres that is
-# used here. If using the GIS-enabled Postgres image, you need to ensure
-# "postGISVersion" matches the version of PostGIS used.
-# imagePostgres: paradedb/paradedb
+  databases:
+    paradedb: paradedb  # Database 'foo' with owner 'zalando'
 
-# imagePgBackRest is the pgBackRest backup utility image. This defaults to the
-# below value.
-# imagePgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.47-0
+  preparedDatabases:  # Pre-defined databases and their configurations
+    paradedb:
+      defaultUsers: true
+      extensions:
+        pg_partman: public
+        pgcrypto: public
+      schemas:
+        data: {}
+        history:
+          defaultRoles: true
+          defaultUsers: false
 
-# imagePgBouncer is the image for the PgBouncer connection pooler. This defaults
-# to the below value.
-# imagePgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.19-4
+  postgresql:
+    version: "15"  # PostgreSQL version to use
+    parameters:  # Custom PostgreSQL parameters
+      shared_buffers: "32MB"
+      max_connections: "10"
+      log_statement: "all"
+#  env:
+#  - name: wal_s3_bucket
+#    value: my-custom-bucket
 
-# imageExporter is the image name for the exporter used as a part of monitoring.
-# This defaults to the value below.
-# imageExporter: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.4.2-0
+  volume:
+    size: 10Gi  # Size of the volume for the PostgreSQL instance
+#    storageClass: my-sc
+#    iops: 1000  # for EBS gp3
+#    throughput: 250  # in MB/s for EBS gp3
+#    selector:
+#      matchExpressions:
+#        - { key: flavour, operator: In, values: [ "banana", "chocolate" ] }
+#      matchLabels:
+#        environment: dev
+#        service: postgres
 
-###########################
-# Basic Postgres Settings #
-###########################
+  additionalVolumes:  # Additional volumes to be mounted to the PostgreSQL pod
+    - name: empty
+      mountPath: /opt/empty  # Mount path inside the container
+      targetContainers:
+        - all  # Target container to mount the volume. 'all' means all containers in the pod.
+      volumeSource:
+        emptyDir: {}  # Type of the volume. Here, it's an empty directory.
+#    - name: data
+#      mountPath: /home/postgres/pgdata/partitions
+#      targetContainers:
+#        - postgres
+#      volumeSource:
+#        PersistentVolumeClaim:
+#          claimName: pvc-postgresql-data-partitions
+#          readyOnly: false
+#    - name: conf
+#      mountPath: /etc/telegraf
+#      subPath: telegraf.conf
+#      targetContainers:
+#        - telegraf-sidecar
+#      volumeSource:
+#        configMap:
+#          name: my-config-map
 
-# instanceName lets you set the name of your instances. This defaults to
-# the value below. Setting "instances" overrides this value.
-# instanceName: instance1
+  enableShmVolume: true  # Enables shared memory volume
+#  spiloRunAsUser: 101
+#  spiloRunAsGroup: 103
+#  spiloFSGroup: 103
+#  podAnnotations:
+#    annotation.key: value
+#  serviceAnnotations:
+#    annotation.key: value
+#  podPriorityClassName: "spilo-pod-priority"
+#  tolerations:
+#  - key: postgres
+#    operator: Exists
+#    effect: NoSchedule
 
-# instanceSize sets the size of the volume that contains the data. This defaults
-# to the value below. Settings "instances" overrides this value.
-# instanceSize: 1Gi
+  resources:  # Resource requests and limits for the PostgreSQL pod
+    requests:
+      cpu: 10m
+      memory: 100Mi
+    limits:
+      cpu: 500m
+      memory: 500Mi
 
-# instanceStorageClassName sets the storage class for the volume that contains the data.
-# This defaults to the "default" storage class defined in the cluster.
-# See: 'kubectl get storageclasses.storage.k8s.io | grep default'
-# Settings "instances" overrides this value.
-# instanceStorageClassName: "hostpath"
+  patroni:  # Configuration for the Patroni PostgreSQL manager
+    failsafe_mode: false
+    initdb:  # Initial database configuration
+      encoding: "UTF8"
+      locale: "en_US.UTF-8"
+      data-checksums: "true"
+    pg_hba:
+      - hostssl all all 0.0.0.0/0 md5
+      - host    all all 0.0.0.0/0 md5
+#    slots:
+#      permanent_physical_1:
+#        type: physical
+#      permanent_logical_1:
+#        type: logical
+#        database: foo
+#        plugin: pgoutput
+    ttl: 30  # Time (in seconds) to live for the leader key in DCS (Distributed Configuration Store)
+    loop_wait: 10  # Delay (in seconds) between iterations for Patroni
+    retry_timeout: 10  # Retry timeout value (in seconds) for Patroni
+    synchronous_mode: false  # Enables or disables synchronous mode for Patroni
+    synchronous_mode_strict: false  # If true, synchronous_mode does not change automatically
+    synchronous_node_count: 1  # Number of nodes that need to be in sync
+    maximum_lag_on_failover: 33554432  # Max lag size on failover
 
-# instanceMemory sets the memory limit for the Postgres instances. This defaults
-# to no limit being set, but an example value is set below. Settings "instances"
-# overrides this value.
-# instanceMemory: 2Gi
+# restore a Postgres DB with point-in-time-recovery
+# with a non-empty timestamp, clone from an S3 bucket using the latest backup before the timestamp
+# with an empty/absent timestamp, clone from an existing alive cluster using pg_basebackup
+#  clone:
+#    uid: "efd12e58-5786-11e8-b5a7-06148230260c"
+#    cluster: "acid-minimal-cluster"
+#    timestamp: "2017-12-19T12:40:33+01:00"  # timezone required (offset relative to UTC, see RFC 3339 section 5.6)
+#    s3_wal_path: "s3://custom/path/to/bucket"
 
-# instanceCPU sets the CPU limit for the Postgres instances. This defaults to
-# no limit being set, but an example value is set below. Setting "instances"
-# overrides this value.
-# instanceCPU: 1000m
+# run periodic backups with k8s cron jobs
+#  enableLogicalBackup: true
+#  logicalBackupSchedule: "30 00 * * *"
 
-# instanceReplicas lets you set the total number of Postgres replicas. This
-# defaults to the value below. More than on replica enables high availability
-# (HA). Settings "instances" overrides this value.
-# instanceReplicas: 1
+#  maintenanceWindows:
+#  - 01:00-06:00  #UTC
+#  - Sat:00:00-04:00
 
-##############################
-# Advanced Postgres Settings #
-##############################
+# overwrite custom properties for connection pooler deployments
+#  connectionPooler:
+#    numberOfInstances: 2
+#    mode: "transaction"
+#    schema: "pooler"
+#    user: "pooler"
+#    maxDBConnections: 60
+#    resources:
+#      requests:
+#        cpu: 300m
+#        memory: 100Mi
+#      limits:
+#        cpu: "1"
+#        memory: 100Mi
 
-# instances allows you to define one or more Postgres instance sets. By default,
-# PGO will only deploy a single instance. Each instance set has similar
-# characteristics to the other instances in the set, e.g. storage size, resource
-# etc. You can have multiple replicas within an instance set.
-#
-# This allows you to fully customize the topology of your Postgres instances.
-#
-# For example, to set up an instance set with HA (due to the default pod
-# topology spread constraints)
-#
-# instances:
-#   - name: pgha1
-#     replicas: 2
-#     dataVolumeClaimSpec:
-#       accessModes:
-#       - "ReadWriteOnce"
-#       resources:
-#         requests:
-#           storage: 1Gi
-# instances: {}
+#   initContainers:
+#   - name: date
+#     image: busybox
+#     command: [ "/bin/date" ]
+#  sidecars:
+#   - name: "telegraf-sidecar"
+#     image: "telegraf:latest"
+#     ports:
+#     - name: metrics
+#       containerPort: 8094
+#       protocol: TCP
+#     resources:
+#       limits:
+#         cpu: 500m
+#         memory: 500Mi
+#       requests:
+#         cpu: 100m
+#         memory: 100Mi
+#     env:
+#       - name: "USEFUL_VAR"
+#         value: "perhaps-true"
 
-# port sets the port that Postgres listens on. Defaults to 5432.
-# port: 5432
+# Custom TLS certificate. Disabled unless tls.secretName has a value.
+  tls:
+    secretName: ""  # should correspond to a Kubernetes Secret resource to load
+    certificateFile: "tls.crt"
+    privateKeyFile: "tls.key"
+    caFile: ""  # optionally configure Postgres with a CA certificate
+    caSecretName: "" # optionally the ca.crt can come from this secret instead.
 
-# patroni lets you set the Patroni configuration for the Postgres cluster.
-# for example, to set up synchronous replication:
-# patroni:
-#   dynamicConfiguration:
-#     synchronous_mode: true
-#     postgresql:
-#       parameters:
-#         synchronous_commit: "on"
-patroni:
-  dynamicConfiguration:
-    postgresql:
-      pg_hba:
-      - host all all 0.0.0.0/0 scram-sha-256
-      - host all all ::1/128 scram-sha-256
+# file names can be also defined with absolute path, and will no longer be relative
+# to the "/tls/" path where the secret is being mounted by default, and "/tlsca/"
+# where the caSecret is mounted by default.
+# When TLS is enabled, also set spiloFSGroup parameter above to the relevant value.
+# if unknown, set it to 103 which is the usual value in the default spilo images.
+# In Openshift, there is no need to set spiloFSGroup/spilo_fsgroup.
 
-# users sets any custom Postgres users and databases that they have  access to
-# as well as any permissions associated with the user account.
-users:
-  - name: paradedb
-    password:
-      type: AlphaNumeric
-    databases:
-    - paradedb
-    options: "SUPERUSER"
+# Add node affinity support by allowing postgres pods to schedule only on nodes that
+# have label: "postgres-operator:enabled" set.
+#  nodeAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#      nodeSelectorTerms:
+#        - matchExpressions:
+#            - key: postgres-operator
+#              operator: In
+#              values:
+#                - enabled
 
-# dataSource specifies a data source for bootstrapping a Postgres cluster.
-# dataSource: {}
-
-# customTLSSecret references a Secret that contains the relevant information for
-# bringing external TLS artifacts to a PostgreSQL cluster. This provides the
-# TLS for the cluster itself.
-# customTLSSecret: {}
-
-# customReplicationTLSSecret references a Secret that contains the relevant
-# information for bringing external TLS artifacts to a PostgreSQL cluster. This
-# provides the information for the replication user.
-# customReplicationTLSSecret: {}
-
-# databaseInitSQL references a ConfigMap that contains a SQL file that should be
-# run a cluster bootstrap.
-# databaseInitSQL:
-#   name: bootstrap-sql
-#   key: bootstrap.sql
-
-# standby sets whether to run this as a standby cluster. Setting "enabled" to
-# "true" enables the standby cluster while "repoName" points to a pgBackRest
-# archive to replay WAL files from, and "host" and "port" point to a primary
-# cluster from which to stream data.
-# standby:
-#   enabled: false
-#   repoName: repo1
-#   host: "192.0.2.2"
-#   port: 5432
-
-# shutdown when set scales the entire workload to zero. By default, this is not
-# set.
-# shutdown: true
-
-#################################
-# Backups / pgBackRest Settings #
-#################################
-
-# backupsSize sets the storage size of the backups to a volume in Kubernetes.
-# can be overridden by "pgBackRestConfig", if set. Defaults to the value below.
-# backupsSize: 1Gi
-
-# backupsStorageClassName sets the storage class to a class existing in Kubernetes.
-# Defaults to the "default" storage class defined in the cluster.
-# Can be overridden by "pgBackRestConfig", if set.
-# backupsStorageClassName: "hostpath"
-
-# s3 allows for AWS S3 or an S3 compatible storage system to be used for
-# backups. This allows for a quick setup with S3; if you need more advanced
-# setup, use pgBackRestConfig.
-# s3:
-#   # bucket specifies the S3 bucket to use,
-#   bucket: ""
-#   # endpoint specifies the S3 endpoint to use.
-#   endpoint: ""
-#   # region specifies the S3 region to use. If your S3 storage system does not
-#   # use "region", fill this in with a random value.
-#   region: ""
-#   # key is the S3 key. This is stored in a Secret.
-#   key: ""
-#   # keySecret is the S3 key secret. This is stored in a Secret.
-#   keySecret: ""
-#   # keyType can be configured to enable IAM integration via AssumeRole
-#   # For more info, see the documentation at https://access.crunchydata.com/documentation/postgres-operator/v5/tutorial/backups/#using-an-aws-integrated-identity-provider-and-role
-#   keyType: ""
-#   # encryptionPassphrase is an optional parameter to enable encrypted backups
-#   # with pgBackRest. This is encrypted by pgBackRest and does not use S3's
-#   # built-in encryption system.
-#   encryptionPassphrase: ""
-
-# gcs allows for Google Cloud Storage (GCS) to be used for backups. This allows
-# for a quick setup with GCS; if you need a more advanced setup, use
-# "pgBackRestConfig".
-# gcs:
-#   # bucket is the name of the GCS bucket that the backups will be stored in.
-#   bucket: ""
-#   # key is a multi-line string that contains the GCS key, which is a JSON
-#   # structure.
-#   key: |
-#     {}
-
-# azure allows for Azure Blob Storage to be used for backups. This allows
-# for a quick setup with Azure Blob Storage; if you need a more advanced setup,
-# use "pgBackRestConfig".
-# azure:
-#   # account is the name of the Azure account to be used.
-#   account: ""
-#   # key is the Secret key used associated with the Azure account.
-#   key: ""
-#   # container is the Azure container that the backups will be stored in.
-#   container: ""
-
-# multiBackupRepos allows for backing up to multiple repositories. This is
-# effectively uses the "quickstarts" for each of the backup types (volume, s3,
-# gcs, azure). You can have any permutation of these types. You can set up to 4.
-# can be overwritten by "pgBackRestConfig".
-#
-# You can't set "multiBackupRepos" and any of the individual quickstarts at the
-# same time. "multiBackupRepos" will take precedence.
-#
-# Below is an example that enables one of each backup type.
-# All available quickstart options are presented below; please see the backup types
-# if you want to see how each option works.
-# multiBackupRepos:
-# - volume:
-#     backupsSize: 1Gi
-# - s3:
-#     bucket: ""
-#     endpoint: ""
-#     region: ""
-#     key: ""
-#     keySecret: ""
-#     keyType: ""
-# - gcs:
-#     bucket: ""
-#     key: |
-#       {}
-# - azure:
-#     account: ""
-#     key: ""
-#     container: ""
-
-# pgBackRestConfig allows for the configuration of every pgBackRest option
-# except for "image", which is set by "pgBackRest".
-# pgBackRestConfig: {}
-
-################################
-# Pooling / pgBouncer Settings #
-################################
-
-# pgBouncerConfig sets all of the pgBouncer portions of the spec except for
-# image. To set image, you need to set the "pgBouncer" setting.
-# pgBouncerConfig: {}
-
-#######################
-# Monitoring Settings #
-#######################
-
-# monitoringConfig sets all of the monitoring portions of the spec except for the
-# image. To set the image, which also enables monitoring, you need to set the
-# "monitoring" setting.
-# monitoringConfig: {}
-
-#######################
-# Kubernetes Settings #
-#######################
-
-# metadata contains any metadata that should be applied to all PGO managed
-# objects in this Postgres cluster. This includes "annotations" and "labels" as
-# sub-keys.
-# metadata: {}
-
-# service customizes the Service that exposes the Postgres primary.
-# service: {}
-
-# imagePullPolicy sets the pull policy for all the images. This defaults to
-# the Kubernetes heuristic:
-# https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-# imagePullPolicy: IfNotPresent
-
-# imagePullSecrets references Secrets that credentials for pulling image from
-# private repositories
-# imagePullSecrets: []
-
-# supplementalGroups sets any group IDs that should be assigned to
-# Pods, particularly around file system constraints within a system
-# supplementalGroups: []
-
-# disableDefaultPodScheduling if set to true, will disable any of the default
-# scheduling constraints for Pods, such as the default Pod Topology Spread
-# Constraints. If set to false or unset, the default scheduling constraints will
-# be used in addition to any customizations that are added in.
-# disableDefaultPodScheduling: false
-
-# openshift can be set explicitly if this is an OpenShift cluster or a cluster
-# that uses a SecurityContextConstraint. This usually does not need to be set,
-# but you may want to explicitly set it to "false" when using an SCC like
-# "anyuid"
-# openshift: false
+# Enables change data capture streams for defined database tables
+#  streams:
+#  - applicationId: test-app
+#    database: foo
+#    tables:
+#      data.state_pending_outbox:
+#        eventType: test-app.status-pending
+#      data.state_approved_outbox:
+#        eventType: test-app.status-approved
+#      data.orders_outbox:
+#        eventType: test-app.order-completed
+#        idColumn: o_id
+#        payloadColumn: o_payload
+#    # Optional. Filter ignores events before a certain txnId and lsn. Can be used to skip bad events
+#    filter:
+#      data.orders_outbox: "[?(@.source.txId > 500 && @.source.lsn > 123456)]"
+#    batchSize: 1000


### PR DESCRIPTION
**Ticket(s) Closed**

N/A

**What**
Switches the Crunchy Postgres Operator for the Zalando Postgres Operator.

**Why**
Because the Crunchy Operator doesn't have an open license on their images, and due to some incompatibilities with starting the ParadeDB image.

**How**
-  Remove dependencies on crunchy operator, instead using the Zalando operator.
- Use the [complete postgres manifest](https://github.com/zalando/postgres-operator/blob/master/manifests/complete-postgres-manifest.yaml) from the Zalando repo to create the `values.yml` file.

**Tests**
None yet.