### PR TITLE
feat: add certificates section

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -12,6 +12,10 @@ spec:
   imageName: {{ .Values.cluster.imageName }}
 {{- end }}
   instances: {{ .Values.cluster.instances }}
+{{- if .Values.cluster.certificates }}
+  certificates: 
+{{ toYaml .Values.cluster.certificates | indent 4}}
+{{- end }}
 {{- if .Values.cluster.startDelay }}
   startDelay: {{ .Values.cluster.startDelay }}
 {{- end }}

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -38,7 +38,7 @@ cluster:
   # Description for the cluster
   description: "Cluster to run ParadeDB"
   # Image for the PostgreSQL instance
-  imageName: docker-paradedb:15-0.2.21
+  imageName: paradedb/paradedb:15-0.2.21
   # Number of instances
   instances: 3
   # Start delay for the instances
@@ -134,6 +134,16 @@ cluster:
     limits:
       memory: "1Gi"
       cpu: "2"
+
+  # Certificates
+  # certificates:
+    # Server certificates
+    # serverCASecret: my-postgresql-server-ca
+    # serverTLSSecret: my-postgresql-server
+
+    # Client certificates
+    # clientCASecret: my-postgres-client-cert
+    # replicationTLSSecret: my-postgres-client-cert
 
   # Affinity configurations for the cluster
   affinity:


### PR DESCRIPTION
**Ticket(s) Closed**
N/A

**What**
Adds the missing section to configure server and client certificates.

**Why**
To support passing certificate secrets to the cluster.

**How**
Adds the `certificates section`

**Tests**
Manually tested