### PR TITLE
fix: give permissions to paradedb user on schemas

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -99,6 +99,14 @@ cluster:
         - CREATE EXTENSION IF NOT EXISTS hypopg CASCADE;
         - CREATE EXTENSION IF NOT EXISTS rum CASCADE;
         - CREATE EXTENSION IF NOT EXISTS age CASCADE;
+        - GRANT USAGE, CREATE ON SCHEMA paradedb TO paradedb;
+        - GRANT USAGE, CREATE ON SCHEMA public TO paradedb;
+        - GRANT ALL ON ALL TABLES IN SCHEMA paradedb TO paradedb;
+        - GRANT ALL ON ALL TABLES IN SCHEMA public TO paradedb;
+        - ALTER DEFAULT PRIVILEGES IN SCHEMA paradedb
+        - GRANT ALL PRIVILEGES ON TABLES TO paradedb;
+        - ALTER DEFAULT PRIVILEGES IN SCHEMA public
+        - GRANT ALL PRIVILEGES ON TABLES TO paradedb;
 
   # Storage configurations for the cluster
   storage:


### PR DESCRIPTION
**Ticket(s) Closed**

N/A

**What**
Gives all permissions and privileges to the `paradedb` user on the `paradedb` and `public` schemas.

**Why**
Because the user couldn't read or create tables with the current implementation.

**How**
Add statements on `postInitApplicationSQL`

**Tests**
Manually tested