### PR TITLE
fix: make paradedb user superuser

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -99,14 +99,7 @@ cluster:
         - CREATE EXTENSION IF NOT EXISTS hypopg CASCADE;
         - CREATE EXTENSION IF NOT EXISTS rum CASCADE;
         - CREATE EXTENSION IF NOT EXISTS age CASCADE;
-        - GRANT USAGE, CREATE ON SCHEMA paradedb TO paradedb;
-        - GRANT USAGE, CREATE ON SCHEMA public TO paradedb;
-        - GRANT ALL ON ALL TABLES IN SCHEMA paradedb TO paradedb;
-        - GRANT ALL ON ALL TABLES IN SCHEMA public TO paradedb;
-        - ALTER DEFAULT PRIVILEGES IN SCHEMA paradedb
-        - GRANT ALL PRIVILEGES ON TABLES TO paradedb;
-        - ALTER DEFAULT PRIVILEGES IN SCHEMA public
-        - GRANT ALL PRIVILEGES ON TABLES TO paradedb;
+        - ALTER USER paradedb WITH SUPERUSER;
 
   # Storage configurations for the cluster
   storage:


### PR DESCRIPTION
**Ticket(s) Closed**

N/A

**What**
After merging #41, I discovered more issues with permissions, specifically because the `paradedb` user didn't have access to the Postgres data directory, required for indexing and searching. After some research it seems the best option is to make the `paradedb` user superuser for now, because Postgres doesn't directly expose a role that grants write permissions.

**Why**
Because for the extensions to work correctly, the user needs permissions on the data directory, which is only available to superusers.

**How**
Add a SQL statement to make the `paradedb` user superuser after initializing the database. The operator doesn't expose a way to directly make a different user superuser, so it is done in SQL.

**Tests**
Manually tested