### PR TITLE
feat: generate Scheduled Backup

### DIFF
--- a/charts/paradedb/templates/backup.yaml
+++ b/charts/paradedb/templates/backup.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.cluster.backup.scheduled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: {{ include "cluster.name" . }}-backup
+spec:
+  suspend: {{ .Values.cluster.backup.scheduled.suspend }}
+  immediate: {{ .Values.cluster.backup.scheduled.immediate }}
+  schedule: {{ .Values.cluster.backup.scheduled.schedule }}
+  backupOwnerReference: {{ .Values.cluster.backup.scheduled.backupOwnerReference }}
+  method: {{ .Values.cluster.backup.scheduled.method }}
+  cluster:
+    name: {{ include "cluster.name" . }}
+{{- end }}

--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -78,6 +78,10 @@ spec:
     barmanObjectStore:
 {{ toYaml .Values.cluster.backup.barmanObjectStore | indent 6 }}
 {{- end }}
+{{- if .Values.cluster.backup.volumeSnapshot }}
+    volumeSnapshot:
+{{ toYaml .Values.cluster.backup.volumeSnapshot | indent 6 }}
+{{- end }}
     retentionPolicy: {{ .Values.cluster.backup.retentionPolicy }}
 {{- end }}
 

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -65,9 +65,11 @@ cluster:
     pg_hba:
       - host all all 10.244.0.0/16 md5
     shared_preload_libraries:
+      - citus
       - pg_cron
       - pg_net
       - pgaudit
+      - pgautofailover
 
   # Bootstrap configuration for the database
   bootstrap:
@@ -77,28 +79,37 @@ cluster:
       # secret:
       #   name: cluster-example-app-user
       postInitApplicationSQL:
-        - CREATE EXTENSION IF NOT EXISTS pg_bm25 CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_cron CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_net CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_ivm CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_graphql CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_hashids CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_jsonschema CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_repack CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_stat_monitor CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pg_hint_plan CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS roaringbitmap CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pgfaceting CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pgtap CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS vector CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pgaudit CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS postgis CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS pgrouting CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS http CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS hypopg CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS rum CASCADE;
-        - CREATE EXTENSION IF NOT EXISTS age CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pgcrypto" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_bm25" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "svector" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_cron" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_net" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_ivm" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_graphql" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_hashids" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_jsonschema" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_repack" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_stat_statements" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_hint_plan" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "roaringbitmap" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pgfaceting" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pgtap" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pgaudit" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "postgis" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pgrouting" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "http" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "hypopg" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "rum" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "age" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "citus" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pgsodium" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_partman" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_jobmon" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pgautofailover" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_show_plans" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "sqlite_fdw" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "ddlx" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "mysql_fdw" CASCADE;
         - ALTER DATABASE paradedb SET search_path TO public,paradedb;
         - ALTER USER paradedb WITH SUPERUSER;
       postInitTemplateSQL:
@@ -129,20 +140,25 @@ cluster:
     #     encryption: AES256
     #     immediateCheckpoint: false
     #     jobs: 2
+
     # Retention policy for the backups
     # retentionPolicy: "30d"
 
-    volumeSnapshot:
-      className: standard
-      walClassName: standard
-      snapshotOwnerReference: backup
+    # For volume snapshots to work, the VolumeSnapshot CRD must be
+    # installed on the cluster.
+    # volumeSnapshot:
+    #   className: standard
+    #   walClassName: standard
+    #   snapshotOwnerReference: backup
 
-    scheduled:
-      suspend: false
-      immediate: true
-      schedule: "0 0 0 * * *"
-      backupOwnerReference: "self"
-      method: "volumeSnapshot"
+    # This will create a ScheduledBackup object. The configuration
+    # for the backup method must be defined.
+    # scheduled:
+    #   suspend: false
+    #   immediate: true
+    #   schedule: "0 0 0 * * *"
+    #   backupOwnerReference: "self"
+    #   method: "barmanObjectStore"
       
 
   # Resource configurations for the cluster

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -153,13 +153,13 @@ cluster:
 
     # This will create a ScheduledBackup object. The configuration
     # for the backup method must be defined.
-    # scheduled:
+    scheduled:
     #   suspend: false
     #   immediate: true
     #   schedule: "0 0 0 * * *"
     #   backupOwnerReference: "self"
     #   method: "barmanObjectStore"
-      
+
 
   # Resource configurations for the cluster
   resources:

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -132,6 +132,19 @@ cluster:
     # Retention policy for the backups
     # retentionPolicy: "30d"
 
+    volumeSnapshot:
+      className: standard
+      walClassName: standard
+      snapshotOwnerReference: backup
+
+    scheduled:
+      suspend: false
+      immediate: true
+      schedule: "0 0 0 * * *"
+      backupOwnerReference: "self"
+      method: "volumeSnapshot"
+      
+
   # Resource configurations for the cluster
   resources:
     requests:


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #40 

**What**
Adds the `ScheduledBackup` object to ther helm chart so users can trigger backups. It also updates the extensions to be compatible with the latest paradedb version.

**Why**
To enable backups and update the chart, it was not working correctly anymore.

**How**
- Update extension list
- Add `ScheduledBackup` template.

**Tests**
Manually tested.