### PR TITLE
fix: use version from Chart.yml

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.25
+appVersion: 0.2.29
 dependencies:
   - name: cloudnative-pg
     version: "0.19.0"

--- a/charts/paradedb/templates/_helpers.tpl
+++ b/charts/paradedb/templates/_helpers.tpl
@@ -5,6 +5,13 @@
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create a default image name
+*/}}
+{{- define "cluster.image" -}}
+{{- printf "%s/%s:%s-v%s" .Chart.Name .Chart.Name .Values.cluster.majorVersion .Chart.AppVersion -}}
+{{- end -}}
+
 {{/* Common labels */}}
 {{- define "cluster.labels" -}}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -8,10 +8,8 @@ spec:
 {{- if .Values.cluster.description }}
   description: {{ .Values.cluster.description }}
 {{- end }}
-{{- if .Values.cluster.imageName }}
-  imageName: {{ .Values.cluster.imageName }}
-{{- end }}
-{{- if .Values.cluster.imageName }}
+  imageName: {{ .Values.cluster.imageName | default (include "cluster.image" .) }}
+{{- if .Values.cluster.imagePullPolicy }}
   imagePullPolicy: {{ .Values.cluster.imagePullPolicy }}
 {{- end }}
   instances: {{ .Values.cluster.instances }}

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -37,8 +37,10 @@ installOperator: true
 cluster:
   # Description for the cluster
   description: "Cluster to run ParadeDB"
-  # Image for the PostgreSQL instance
-  imageName: paradedb/paradedb:15-v0.2.25
+  # Postgres major version
+  majorVersion: "15"
+  # Override image for the PostgreSQL instance
+  # imageName: ""
   # Image pull policy
   imagePullPolicy: IfNotPresent
   # Number of instances


### PR DESCRIPTION
**Ticket(s) Closed**

N/A

**What**
Use the `AppVersion` key from the `Chart.yaml` file. 

**Why**
Because the version was hardcoded in the `values.yaml` file, and this way the version can be modified more easily. However, at this point there is still no automation in place to increase the version automatically, and it likely won't be implemented until there are more safety mechanisms.

**How**
Define a default value in `_helpers.tpl`, following the format of `paraded/paradedb-{pgmajorversion}-v{paradedbversion}`

**Tests**
Manually tested