### PR TITLE
fix: vaccum dummy table on initialization

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.10
+version: 0.4.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -100,6 +100,7 @@ cluster:
         - CREATE EXTENSION IF NOT EXISTS rum CASCADE;
         - CREATE EXTENSION IF NOT EXISTS age CASCADE;
         - ALTER USER paradedb WITH SUPERUSER;
+        - VACUUM FULL paradedb.mock_items;
 
   # Storage configurations for the cluster
   storage:


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
Run a vaccum on the dummy `mock_items` table.

**Why**
See https://github.com/paradedb/paradedb/pull/487 for more information.

**How**
Add SQL instruction to vaccum

**Tests**
Manually tested