### PR TITLE
fix: set search path correctly

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.11
+version: 0.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -101,6 +101,8 @@ cluster:
         - CREATE EXTENSION IF NOT EXISTS age CASCADE;
         - ALTER DATABASE paradedb SET search_path TO public,paradedb;
         - ALTER USER paradedb WITH SUPERUSER;
+      postInitTemplateSQL:
+        - ALTER DATABASE template1 SET search_path TO public,paradedb;
 
   # Storage configurations for the cluster
   storage:

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -99,8 +99,8 @@ cluster:
         - CREATE EXTENSION IF NOT EXISTS hypopg CASCADE;
         - CREATE EXTENSION IF NOT EXISTS rum CASCADE;
         - CREATE EXTENSION IF NOT EXISTS age CASCADE;
+        - ALTER DATABASE paradedb SET search_path TO public,paradedb;
         - ALTER USER paradedb WITH SUPERUSER;
-        - VACUUM FULL paradedb.mock_items;
 
   # Storage configurations for the cluster
   storage:


### PR DESCRIPTION
**Ticket(s) Closed**

N/A

**What**
Sets the search path for the `paradedb` database to use the `public` schema by default.

**Why**
See: https://github.com/paradedb/paradedb/pull/487

**How**
Use the `SET search_path` command.
Add `postInitTemplateSQL` spec.

**Tests**
