### PR TITLE
fix: remove mock items vacuum

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -100,7 +100,6 @@ cluster:
         - CREATE EXTENSION IF NOT EXISTS age CASCADE;
         - ALTER DATABASE paradedb SET search_path TO public,paradedb;
         - ALTER USER paradedb WITH SUPERUSER;
-        - VACUUM FULL paradedb.mock_items;
       postInitTemplateSQL:
         - ALTER DATABASE template1 SET search_path TO public,paradedb;
 


### PR DESCRIPTION
**Ticket(s) Closed**

- Closes #

**What**
Removes the `VACUUM`  SQL command when creating database.

**Why**
Because the `mock_items` table was made optional, so the vacuum command is no longer needed.

**How**

**Tests**
