### PR TITLE
chore: Update `pg_bm25` references to `pg_search`

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/paradedb/helm-charts
 icon: https://raw.githubusercontent.com/paradedb/paradedb/dev/docs/logo/readme.svg
 keywords:
   - paradedb
-  - pg_bm25
   - pg_analytics
+  - pg_search
 maintainers:
   - name: ParadeDB
     url: https://paradedb.github.io/helm-charts/

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -78,8 +78,8 @@ cluster:
       # secret:
       #   name: cluster-example-app-user
       postInitApplicationSQL:
-        - CREATE EXTENSION IF NOT EXISTS "pg_search" CASCADE;
         - CREATE EXTENSION IF NOT EXISTS "pg_analytics" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_search" CASCADE;
         - CREATE EXTENSION IF NOT EXISTS "svector" CASCADE;
         - CREATE EXTENSION IF NOT EXISTS "vector" CASCADE;
         - ALTER DATABASE paradedb SET search_path TO public,paradedb;

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -67,8 +67,8 @@ cluster:
     shared_preload_libraries:
       - pgaudit
       - pg_cron
-      - pg_bm25
       - pg_analytics
+      - pg_search
 
   # Bootstrap configuration for the database
   bootstrap:
@@ -78,7 +78,7 @@ cluster:
       # secret:
       #   name: cluster-example-app-user
       postInitApplicationSQL:
-        - CREATE EXTENSION IF NOT EXISTS "pg_bm25" CASCADE;
+        - CREATE EXTENSION IF NOT EXISTS "pg_search" CASCADE;
         - CREATE EXTENSION IF NOT EXISTS "pg_analytics" CASCADE;
         - CREATE EXTENSION IF NOT EXISTS "svector" CASCADE;
         - CREATE EXTENSION IF NOT EXISTS "vector" CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We recently renamed the `pg_bm25` extension to `pg_search`, as we look to improve/unify our branding and to mark the "v1.0" of `pg_search`. This PR makes the relevant fixes here.

Note that the `helm-charts` are still broken since we swapped to the Bitnami PostgreSQL image. We'll need to investigate that in due time, and fix it. But for now, this change is necessary anyways.

## Why
^

## How
^

## Tests
^