### PR TITLE
fix: add postgres user uid and gid

### DIFF
--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -28,6 +28,9 @@ spec:
   primaryUpdateStrategy: {{ .Values.cluster.primaryUpdateStrategy }}
 {{- end }}
 
+  postgresUID: {{ .Values.cluster.postgresUID }}
+  postgresGID: {{ .Values.cluster.postgresGID }}
+
 {{- if .Values.cluster.postgresql }}
   postgresql:
 {{- if .Values.cluster.postgresql.parameters }}

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -52,6 +52,11 @@ cluster:
   # Update strategy for the primary
   primaryUpdateStrategy: unsupervised
 
+  # User and group ids of the postgres user, must exist on the base image
+  # so the operator can start the postgres server.
+  postgresUID: 1001
+  postgresGID: 1001
+
   # PostgreSQL specific configurations
   postgresql:
     parameters:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Add the `postgresUID` and `postgresGID` ovveride fields to the cluster so they can be set to the same as the paradedb docker image.

## Why

## How

## Tests
