### PR TITLE
feat: add Helmfile and Helm installations

### DIFF
--- a/.github/workflows/lint-helm.yml
+++ b/.github/workflows/lint-helm.yml
@@ -8,8 +8,8 @@ name: Lint Helm
 on:
   pull_request:
     paths:
-      - 'charts/paradedb/*'
-      - '.github/workflows/lint-helm.yml'
+      - "charts/paradedb/*"
+      - ".github/workflows/lint-helm.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-helm.yml
+++ b/.github/workflows/lint-helm.yml
@@ -8,8 +8,8 @@ name: Lint Helm
 on:
   pull_request:
     paths:
-      - "charts/paradedb/*"
-      - ".github/workflows/lint-helm.yml"
+      - 'charts/paradedb/*'
+      - '.github/workflows/lint-helm.yml'
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ chmod 700 get_helm.sh
 
 See the [Helm docs](https://helm.sh/docs/intro/install/) for more information.
 
-### Installing the ParadeDB Helm Chart
+### Install the ParadeDB Helm Chart
 
-Once the operator is installed, add the ParadeDB repo to Helm as follows:
+First, add the ParadeDB repo to Helm as follows:
 
 ```bash
 helm repo add paradedb https://paradedb.github.io/helm-charts

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This repository contains the Helm chart for deploying and managing ParadeDB on K
 
 - A Kubernetes cluster with at least v1.21
 - [Helm](https://helm.sh/)
-- [CloudNative Operator](https://cloudnative-pg.io/) installed on the Kubernetes cluster
 
 ## Usage
 
@@ -46,30 +45,7 @@ chmod 700 get_helm.sh
 
 See the [Helm docs](https://helm.sh/docs/intro/install/) for more information.
 
-### Install CloudNative Operator
-
-This chart does not include the Custom Resource Definitions (CRDs) from the
-CloudNative Operator, and it doesn't explicitly depend on it due to Helm's
-constraints with CRD management. As such, the operator itself is not bundled
-within this chart.
-
-To use this chart, you need to independently install the operator CRDs. You can
-install the operator using the
-[official helm chart](https://github.com/cloudnative-pg/charts).
-
-```bash
-helm repo add cnpg https://cloudnative-pg.github.io/charts
-helm upgrade --install cnpg \
-  --namespace cnpg-system \
-  --create-namespace \
-  cnpg/cloudnative-pg
-```
-
-It is also possible to install using the manifest directly. See the operator
-[installation documentation](https://cloudnative-pg.io/documentation/1.21/installation_upgrade/#installation-on-kubernetes)
-for more information.
-
-### Install ParadeDB Helm Chart
+### Installing the ParadeDB Helm Chart
 
 Once the operator is installed, add the ParadeDB repo to Helm as follows:
 
@@ -94,13 +70,33 @@ helm delete <my-db>
 
 You can also download the chart directly from [Artifact Hub](https://artifacthub.io/packages/helm/paradedb/paradedb).
 
+### Installing using Helmfile
+
+You can install ParadeDB using [Helmfile](https://helmfile.readthedocs.io/en/latest/). Once helmfile is installed, you can download the `helmfile.yaml` file from this repository and run:
+
+```bash
+helmfile apply
+```
+
+You can configure values inside the `helmfile.yaml`. For a list of possible configurations, see the [bitnami chart parameters](https://github.com/bitnami/charts/tree/main/bitnami/postgresql#parameters)
+
+### Installing using Helm
+
+You can install ParadeDB using Helm and the Bitnami Postgres chart. To do so, run:
+
+```bash
+helm install paradedb oci://registry-1.docker.io/bitnamicharts/postgresql --namespace paradedb --create-namespace --values values.yaml
+```
+
+You can configure values inside the `helmfile.yaml`. For a list of possible configurations, see the [bitnami chart parameters](https://github.com/bitnami/charts/tree/main/bitnami/postgresql#parameters)
+
 ## Configuration
 
 The ParadeDB Helm chart can be configured using the `values.yaml` file or by
 specifying values on the command line during installation.
 
 Check the [values.yaml](https://github.com/paradedb/helm-charts/blob/main/charts/paradedb/values.yaml)
-file for more information.
+file for more information. The values passed in correspond to the ones in [bitnami chart parameters](https://github.com/bitnami/charts/tree/main/bitnami/postgresql#parameters).
 
 ## Development
 

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -1,7 +1,7 @@
 paradedb:
   image:
     repository: paradedb/paradedb
-    tag: 16-v0.6.0
+    tag: latest
 
   auth:
     # Username

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,0 +1,23 @@
+repositories:
+  - name: bitnami
+    url: registry-1.docker.io/bitnamicharts
+    oci: true
+
+releases:
+  - name: paradedb
+    namespace: paradedb
+    chart: bitnami/postgresql
+    version: 15.2.5
+    set:
+      - name: image.repository
+        value: paradedb/paradedb
+      - name: image.tag
+        value: latest
+
+      - name: auth.username
+        value: paradedb
+      - name: auth.database
+        value: paradedb
+
+      - name: postgresqlSharedPreloadLibraries
+        value: 'pgaudit,pg_cron,pg_search,pg_analytics'

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -20,4 +20,4 @@ releases:
         value: paradedb
 
       - name: postgresqlSharedPreloadLibraries
-        value: 'pgaudit,pg_cron,pg_search,pg_analytics'
+        value: "pgaudit,pg_cron,pg_search,pg_analytics"

--- a/values.yaml
+++ b/values.yaml
@@ -16,4 +16,4 @@ auth:
   database: paradedb
 
 # Shared preload libraries (comma-separated list)
-postgresqlSharedPreloadLibraries: 'pgaudit,pg_cron,pg_search,pg_analytics'
+postgresqlSharedPreloadLibraries: "pgaudit,pg_cron,pg_search,pg_analytics"

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,19 @@
+image:
+  repository: paradedb/paradedb
+  tag: latest
+
+auth:
+  # username
+  username: paradedb
+
+  # Password for the user
+  # password:
+
+  # existing password secret name
+  # existingSecret:
+
+  # database name to create
+  database: paradedb
+
+# Shared preload libraries (comma-separated list)
+postgresqlSharedPreloadLibraries: 'pgaudit,pg_cron,pg_search,pg_analytics'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
This PR adds different ways to install ParadeDB to a Kubernetes cluster.  The three proposed ways are:
1. Using a ParadeDB helm chart
3. Using the Bitnami chart with ParadeDB provided `values.yaml` file
4. Using the Bitnami chart, values set inside a `helmfile.yaml` file

All if them work similarly but the main difference is that for approach 1 a ParadeDB helm chart needs to be maintained. The other approaches instead use the Bitnami chart directly and rely on setting the config for the user, the only thing that changes is the tool they use but they are mostly the same.

Note that the top-level `values.yaml` file is different than the one inside `charts/paradedb`, because the latter is using the bitnami chart as a dependency, but the former is using it directly.


In case that approach 1 is kept, this PR fixes the hardcoded image tag and instead sets it to `latest`.

## Why

## How

## Tests
