### PR TITLE
chore: Update Helm Charts to `pg_lakehouse`

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     # We set the alias to paradedb so resources are named 'paradedb'
     alias: paradedb
     # The version of the Bitnami PostgreSQL chart
-    version: 15.5.1
+    version: 15.5.0
     repository: oci://registry-1.docker.io/bitnamicharts
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     # We set the alias to paradedb so resources are named 'paradedb'
     alias: paradedb
     # The version of the Bitnami PostgreSQL chart
-    version: 15.2.5
+    version: 15.5.1
     repository: oci://registry-1.docker.io/bitnamicharts
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/paradedb/helm-charts
 icon: https://raw.githubusercontent.com/paradedb/paradedb/dev/docs/logo/readme.svg
 keywords:
   - paradedb
-  - pg_analytics
+  - pg_lakehouse
   - pg_search
 maintainers:
   - name: ParadeDB

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -17,4 +17,4 @@ paradedb:
     database: paradedb
 
   # Shared preload libraries (comma-separated list)
-  postgresqlSharedPreloadLibraries: "pgaudit,pg_cron,pg_search,pg_analytics"
+  postgresqlSharedPreloadLibraries: "pgaudit,pg_cron,pg_search,pg_lakehouse"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -7,7 +7,7 @@ releases:
   - name: paradedb
     namespace: paradedb
     chart: bitnami/postgresql
-    version: 15.5.1
+    version: 15.5.0
     set:
       - name: image.repository
         value: paradedb/paradedb

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -7,7 +7,7 @@ releases:
   - name: paradedb
     namespace: paradedb
     chart: bitnami/postgresql
-    version: 15.2.5
+    version: 15.5.1
     set:
       - name: image.repository
         value: paradedb/paradedb
@@ -20,4 +20,4 @@ releases:
         value: paradedb
 
       - name: postgresqlSharedPreloadLibraries
-        value: "pgaudit,pg_cron,pg_search,pg_analytics"
+        value: "pgaudit,pg_cron,pg_search,pg_lakehouse"

--- a/values.yaml
+++ b/values.yaml
@@ -16,4 +16,4 @@ auth:
   database: paradedb
 
 # Shared preload libraries (comma-separated list)
-postgresqlSharedPreloadLibraries: "pgaudit,pg_cron,pg_search,pg_analytics"
+postgresqlSharedPreloadLibraries: "pgaudit,pg_cron,pg_search,pg_lakehouse"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
The chart had not been updated to `pg_lakehouse`, since we deprecated `pg_analytics. This fixes it. I also upgrade the Bitnami chart.

## Why

## How

## Tests
