### PR TITLE
chore: Remove pg_cron

### DIFF
--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -17,4 +17,4 @@ paradedb:
     database: paradedb
 
   # Shared preload libraries (comma-separated list)
-  postgresqlSharedPreloadLibraries: "pgaudit,pg_cron,pg_search,pg_lakehouse"
+  postgresqlSharedPreloadLibraries: "pgaudit,pg_lakehouse,pg_search"

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -20,4 +20,4 @@ releases:
         value: paradedb
 
       - name: postgresqlSharedPreloadLibraries
-        value: "pgaudit,pg_cron,pg_search,pg_lakehouse"
+        value: "pgaudit,pg_lakehouse,pg_search"

--- a/values.yaml
+++ b/values.yaml
@@ -16,4 +16,4 @@ auth:
   database: paradedb
 
 # Shared preload libraries (comma-separated list)
-postgresqlSharedPreloadLibraries: "pgaudit,pg_cron,pg_search,pg_lakehouse"
+postgresqlSharedPreloadLibraries: "pgaudit,pg_lakehouse,pg_search"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
Sister PR: https://github.com/paradedb/paradedb/pull/1291

We added `pg_cron` at a time when we expected people to do a lot of data transformation between row-oriented and column-oriented tables. We no longer plan to support this workload, and we haven't seen any demand for `pg_cron`, so I'm going to remove it in the meantime.

## Why
Remove bloat/room for problems.

## How
N/A

## Tests
N/A